### PR TITLE
Remove aggregate download size from `AppDownloadInfo`

### DIFF
--- a/accrescent/directory/v1/app_download_info.proto
+++ b/accrescent/directory/v1/app_download_info.proto
@@ -12,9 +12,6 @@ option java_multiple_files = true;
 option java_package = "app.accrescent.directory.v1";
 
 message AppDownloadInfo {
-  // The total download size in bytes for this app or app update.
-  optional uint32 download_size = 1;
-
   // Download info for each individual split APK
-  repeated SplitDownloadInfo split_download_info = 2;
+  repeated SplitDownloadInfo split_download_info = 1;
 }


### PR DESCRIPTION
This field doesn't make sense to include since 1. clients can add up the download sizes from each SplitDownloadInfo themselves anyway and 2. it would become obsolete if we support compressed downloads and/or delta updates as we plan to since those will impact the total download size in ways that depend upon what the client supports.