### PR TITLE
Add package info to `AppDownloadInfo`

### DIFF
--- a/accrescent/directory/v1/app_download_info.proto
+++ b/accrescent/directory/v1/app_download_info.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 
 package accrescent.directory.v1;
 
+import "accrescent/directory/v1/package_info.proto";
 import "accrescent/directory/v1/split_download_info.proto";
 
 option java_multiple_files = true;
@@ -14,4 +15,7 @@ option java_package = "app.accrescent.directory.v1";
 message AppDownloadInfo {
   // Download info for each individual split APK
   repeated SplitDownloadInfo split_download_info = 1;
+
+  // Package information for this app.
+  PackageInfo package_info = 2;
 }


### PR DESCRIPTION
There are many cases in which a client may want to know the exact package information for the app described in an AppDownloadInfo. While clients can access package info for the app in a way by calling GetAppPackageInfo() with the same app ID passed to GetAppDownloadInfo(), there is no guarantee that the app won't be updated between these calls, meaning a client attempting to correlate package info with download info cannot guarantee that they match.

Therefore, include package info in AppDownloadInfo so that clients can atomically retrieve both package info and download info in the same request to guarantee they correlate to each other.