### PR TITLE
Make version codes 64-bit

### DIFF
--- a/accrescent/directory/v1/get_app_download_info_request.proto
+++ b/accrescent/directory/v1/get_app_download_info_request.proto
@@ -23,5 +23,5 @@ message GetAppDownloadInfoRequest {
   // The base version of the app to get download info from (almost always the
   // currently installed version). If unspecified, indicates that this is an
   // initial installation instead of an update.
-  optional uint32 base_version_code = 3;
+  optional uint64 base_version_code = 3;
 }

--- a/accrescent/directory/v1/package_info.proto
+++ b/accrescent/directory/v1/package_info.proto
@@ -12,7 +12,7 @@ option java_package = "app.accrescent.directory.v1";
 // Package information for a given app.
 message PackageInfo {
   // The app's version code.
-  optional uint32 version_code = 1;
+  optional uint64 version_code = 1;
 
   // The app's human-readable version name.
   optional string version_name = 2;


### PR DESCRIPTION
Version codes on Android have traditionally been represented as 32-bit integers. However, since API 28 (Android 9), a versionCodeMajor attribute is available which extends the version code my another 32 bits, making it effectively a 64-bit integer. This fact is represented in the Android platform's `PackageInfo.versionCode` property being deprecated since Android 9 in favor of
`PackageInfo.getLongVersionCode()`.

Therefore, we should represent applications' canonical version codes as 64-bit integers to ensure we can accept all valid version codes including those incorporating versionCodeMajor.

References:

https://developer.android.com/reference/android/R.styleable#AndroidManifest_versionCodeMajor https://developer.android.com/reference/android/content/pm/PackageInfo#versionCode https://developer.android.com/reference/android/content/pm/PackageInfo#getLongVersionCode()